### PR TITLE
change python default lsp to ruff

### DIFF
--- a/src/file_types.zig
+++ b/src/file_types.zig
@@ -440,7 +440,8 @@ pub const python = .{
     .extensions = .{ "py", "pyi" },
     .comment = "#",
     .first_line_matches = FirstLineMatch{ .prefix = "#!", .content = "python" },
-    .language_server = .{"pylsp"},
+    .language_server = .{"ruff", "server"},
+    .formatter = .{"ruff", "format", "-"},
 };
 
 pub const regex = .{


### PR DESCRIPTION
ruff is much faster than pylsp so it would be a good fit for flow. And it has an autoformatter