### PR TITLE
Add just & bibtex support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,7 @@ pub fn build(b: *std.Build) void {
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-jsdoc/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-json/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-julia/queries/highlights.scm");
+    ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-just/queries/just/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-kdl/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-kotlin/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-lua/queries/highlights.scm");
@@ -143,6 +144,7 @@ pub fn build(b: *std.Build) void {
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-html/queries/injections.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-hurl/queries/injections.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-javascript/queries/injections.scm");
+    ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-just/queries/just/injections.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-kdl/queries/injections.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-lua/queries/injections.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-markdown/tree-sitter-markdown-inline/queries/injections.scm");

--- a/build.zig
+++ b/build.zig
@@ -44,6 +44,7 @@ pub fn build(b: *std.Build) void {
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-astro/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-awk/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-bash/queries/highlights.scm");
+    ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-bibtex/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-c-sharp/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-c/queries/highlights.scm");
     ts_queryfile(b, tree_sitter_dep, ts_bin_query_gen, "tree-sitter-c3/queries/highlights.scm");

--- a/src/file_types.zig
+++ b/src/file_types.zig
@@ -39,6 +39,13 @@ pub const bash = .{
     .first_line_matches = FirstLineMatch{ .prefix = "#!", .content = "sh" },
 };
 
+pub const bibtex = .{
+    .description = "BibTeX",
+    .icon = "",
+    .extensions = .{ "bib" },
+    .comment = "%",
+};
+
 pub const c = .{
     .description = "C",
     .icon = "",

--- a/src/file_types.zig
+++ b/src/file_types.zig
@@ -332,6 +332,13 @@ pub const julia = .{
     .comment = "#",
 };
 
+pub const just = .{
+    .description = "Just",
+    .icon = "J",
+    .extensions = .{"Justfile", "justfile"},
+    .comment = "#",
+};
+
 pub const kdl = .{
     .description = "KDL",
     .color = 0x000000,


### PR DESCRIPTION
Couldn’t test the changes in flow due to different zig versions used, but they should be safe. Should I move bibtex next to latex? Depends on https://github.com/neurocyte/tree-sitter/pull/19, I suppose I should wait for it and update the dependency once merged.